### PR TITLE
Make the backend use the same order of specificity as other hiera backends

### DIFF
--- a/lib/hiera/backend/file_backend.rb
+++ b/lib/hiera/backend/file_backend.rb
@@ -23,6 +23,7 @@ class Hiera
           data = File.read(abs_path)
           next unless data
           answer = data
+          break
         end
         return answer
       end


### PR DESCRIPTION
Given hiera.yaml:
%{environment}/%{calling_module}
common/%{calling_module}

..and filesystem:
development/ntp.d/ntp.conf
common/ntp.d/ntp.conf

The current implementation will keep iterating through to the least specific match, in contrast to other hiera backends.

This pull request breaks the loop when a file is found.
